### PR TITLE
Add xwrf/wrf DataArray and Dataset Accessors

### DIFF
--- a/xwrf/__init__.py
+++ b/xwrf/__init__.py
@@ -5,6 +5,7 @@
 from pkg_resources import DistributionNotFound, get_distribution
 
 from . import config
+from .accessors import WRFDataArrayAccessor, WRFDatasetAccessor
 from .io_plugin import WRFBackendEntrypoint
 
 try:

--- a/xwrf/accessors.py
+++ b/xwrf/accessors.py
@@ -1,0 +1,41 @@
+import typing
+
+import xarray as xr
+
+from .postprocess import _decode_times, _make_units_quantify_read, _modify_attrs_to_cf
+
+
+class WRFAccessor:
+    """
+    Common Dataset and DataArray accessor functionality.
+    """
+
+    def __init__(self, xarray_obj: typing.Union[xr.Dataset, xr.DataArray]):
+        self.xarray_obj = xarray_obj.copy()
+
+
+@xr.register_dataarray_accessor('wrf')
+@xr.register_dataarray_accessor('xwrf')
+class WRFDataArrayAccessor(WRFAccessor):
+    """Adds a number of WRF specific methods to xarray.DataArray objects."""
+
+
+@xr.register_dataset_accessor('wrf')
+@xr.register_dataset_accessor('xwrf')
+class WRFDatasetAccessor(WRFAccessor):
+    """Adds a number of WRF specific methods to xarray.Dataset objects."""
+
+    def postprocess(self, decode_times=True) -> xr.Dataset:
+        """
+        Postprocess the dataset.
+
+        Returns
+        -------
+        xarray.Dataset
+            The postprocessed dataset.
+        """
+        ds = self.xarray_obj.pipe(_modify_attrs_to_cf).pipe(_make_units_quantify_read)
+        if decode_times:
+            ds = ds.pipe(_decode_times)
+
+        return ds

--- a/xwrf/config.yaml
+++ b/xwrf/config.yaml
@@ -1,5 +1,30 @@
 version: 0.1
 
+latitude_coords:
+  - CLAT
+  - XLAT
+  - XLAT_C
+  - XLAT_M
+  - XLAT_U
+  - XLAT_V
+
+longitude_coords:
+  - CLONG
+  - XLONG
+  - XLONG_C
+  - XLONG_M
+  - XLONG_U
+  - XLONG_V
+
+time_coords:
+  - XTIME
+  - Times
+  - Time
+  - time
+boolean_units_attrs:
+  - '-'
+  - flag
+
 cf_attribute_map:
   ZNW:
     standard_name: atmosphere_hybrid_sigma_pressure_coordinate

--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -1,0 +1,35 @@
+import pandas as pd
+import xarray as xr
+
+from .config import config
+
+
+def _decode_times(ds: xr.Dataset) -> xr.Dataset:
+    """
+    Decode the time variable to datetime64.
+    """
+    ds = ds.assign_coords(
+        {
+            'Time': pd.to_datetime(
+                ds.Times.data.astype('str'), errors='raise', format='%Y-%m-%d_%H:%M:%S'
+            )
+        }
+    )
+    ds.Time.attrs = {'long_name': 'Time', 'standard_name': 'time'}
+    return ds
+
+
+def _make_units_quantify_read(ds: xr.Dataset) -> xr.Dataset:
+    boolean_units_attrs = config.get('boolean_units_attrs')
+    for variable in ds.data_vars:
+        if ds[variable].attrs.get('units') in boolean_units_attrs:
+            ds[variable].attrs.pop('units', None)
+    return ds
+
+
+def _modify_attrs_to_cf(ds: xr.Dataset) -> xr.Dataset:
+    """Modify the attributes of the dataset to comply with CF conventions."""
+    vars_to_update = set(config.get('cf_attribute_map').keys()).intersection(set(ds.data_vars))
+    for variable in vars_to_update:
+        ds[variable].attrs.update(config.get(f'cf_attribute_map.{variable}'))
+    return ds


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

This PR adds an `wrf(xwrf)` accessor  as discussed in #20. As part of this accessor, `xwrf` postprocesses the data by doing the following: 

- Modifying the CF attributes as defined in the config file 
- Fixing the boolean units attrs
- Decoding the `Times` 

The result is a dataset that can be understood by `cf-xarray`. For instance: 

<details>

<summary>Before</summary>

```python
In [1]: import xwrf

In [2]: import xarray as xr

In [3]: import cf_xarray

In [4]: ds = xr.open_dataset("/Users/abanihi/Downloads/wrfout_example.nc")

In [5]: ds
Out[5]: 
<xarray.Dataset>
Dimensions:                (Time: 24, south_north: 29, west_east: 31,
                            bottom_top: 39, bottom_top_stag: 40,
                            soil_layers_stag: 5, west_east_stag: 32,
                            south_north_stag: 30, seed_dim_stag: 8)
Coordinates:
    XLAT                   (Time, south_north, west_east) float32 ...
    XLONG                  (Time, south_north, west_east) float32 ...
    XTIME                  (Time) datetime64[ns] ...
    XLAT_U                 (Time, south_north, west_east_stag) float32 ...
    XLONG_U                (Time, south_north, west_east_stag) float32 ...
    XLAT_V                 (Time, south_north_stag, west_east) float32 ...
    XLONG_V                (Time, south_north_stag, west_east) float32 ...
Dimensions without coordinates: Time, south_north, west_east, bottom_top,
                                bottom_top_stag, soil_layers_stag,
                                west_east_stag, south_north_stag, seed_dim_stag
Data variables: (12/205)
    Times                  (Time) |S19 ...
    LU_INDEX               (Time, south_north, west_east) float32 ...
    ZNU                    (Time, bottom_top) float32 ...
    ZNW                    (Time, bottom_top_stag) float32 ...
    ZS                     (Time, soil_layers_stag) float32 ...
    DZS                    (Time, soil_layers_stag) float32 ...
    ...                     ...
    PCB                    (Time, south_north, west_east) float32 ...
    PC                     (Time, south_north, west_east) float32 ...
    LANDMASK               (Time, south_north, west_east) float32 ...
    LAKEMASK               (Time, south_north, west_east) float32 ...
    SST                    (Time, south_north, west_east) float32 ...
    SST_INPUT              (Time, south_north, west_east) float32 ...
...
```

```python
In [6]: ds.cf
Out[6]: 
Coordinates:
- CF Axes:   X, Y, Z, T: n/a

- CF Coordinates:   longitude: ['XLONG', 'XLONG_U', 'XLONG_V']
                    latitude: ['XLAT', 'XLAT_U', 'XLAT_V']
                    vertical, time: n/a

- Cell Measures:   area, volume: n/a

- Standard Names:   n/a

- Bounds:   n/a

Data Variables:
- Cell Measures:   area, volume: n/a

- Standard Names:   n/a

- Bounds:   n/a
```

</details>


Use the `.xwrf` or `.wrf` accessor to postprocess the data 

```python
In [7]: ds = ds.xwrf.postprocess(decode_times=True)
```

<details>

<summary>After</summary>

```python
In [8]: ds
Out[8]: 
<xarray.Dataset>
Dimensions:                (Time: 24, south_north: 29, west_east: 31,
                            bottom_top: 39, bottom_top_stag: 40,
                            soil_layers_stag: 5, west_east_stag: 32,
                            south_north_stag: 30, seed_dim_stag: 8)
Coordinates:
    XLAT                   (Time, south_north, west_east) float32 63.34 ... 6...
    XLONG                  (Time, south_north, west_east) float32 -19.38 ... ...
    XTIME                  (Time) datetime64[ns] 2020-03-19 ... 2020-03-19T23...
    XLAT_U                 (Time, south_north, west_east_stag) float32 63.34 ...
    XLONG_U                (Time, south_north, west_east_stag) float32 -19.39...
    XLAT_V                 (Time, south_north_stag, west_east) float32 63.33 ...
    XLONG_V                (Time, south_north_stag, west_east) float32 -19.38...
  * Time                   (Time) datetime64[ns] 2020-03-19 ... 2020-03-19T23...
Dimensions without coordinates: south_north, west_east, bottom_top,
                                bottom_top_stag, soil_layers_stag,
                                west_east_stag, south_north_stag, seed_dim_stag
Data variables: (12/205)
    Times                  (Time) |S19 b'2020-03-19_00:00:00' ... b'2020-03-1...
    LU_INDEX               (Time, south_north, west_east) float32 ...
    ZNU                    (Time, bottom_top) float32 ...
    ZNW                    (Time, bottom_top_stag) float32 ...
    ZS                     (Time, soil_layers_stag) float32 ...
    DZS                    (Time, soil_layers_stag) float32 ...
    ...                     ...
    PCB                    (Time, south_north, west_east) float32 ...
    PC                     (Time, south_north, west_east) float32 ...
    LANDMASK               (Time, south_north, west_east) float32 ...
    LAKEMASK               (Time, south_north, west_east) float32 ...
    SST                    (Time, south_north, west_east) float32 ...
    SST_INPUT              (Time, south_north, west_east) float32 ...

...
```


```python
In [9]: ds.cf
Out[9]: 
Coordinates:
- CF Axes: * T: ['Time']
             X, Y, Z: n/a

- CF Coordinates:   longitude: ['XLONG', 'XLONG_U', 'XLONG_V']
                    latitude: ['XLAT', 'XLAT_U', 'XLAT_V']
                  * time: ['Time']
                    vertical: n/a

- Cell Measures:   area, volume: n/a

- Standard Names: * time: ['Time']

- Bounds:   n/a

Data Variables:
- Cell Measures:   area, volume: n/a

- Standard Names:   air_potential_temperature: ['TH2']
                    air_pressure: ['PSFC']
                    air_temperature: ['T2']
                    atmosphere_boundary_layer_thickness: ['PBLH']
                    atmosphere_hybrid_sigma_pressure_coordinate: ['ZNU', 'ZNW']
                    cloud_area_fraction_in_atmosphere_layer: ['CLDFRA']
                    humidity_mixing_ratio: ['Q2', 'QVAPOR']
                    integral_of_lwe_precipitation_rate_wrt_time: ['RAINNC']
                    integral_of_surface_upward_heat_flux_in_air_wrt_time: ['ACHFX']
                    integral_of_surface_upward_latent_heat_flux_in_air_wrf_time: ['ACLHF']
                    leaf_area_index: ['LAI']
                    surface_altitude: ['HGT']
                    surface_upward_heat_flux_in_air: ['HFX']
                    surface_upward_latent_heat_flux_in_air: ['LH']
                    upward_air_velocity: ['W']
                    vegetation_area_fraction: ['VEGFRA']
                    x_wind: ['U', 'U10']
                    y_wind: ['V', 'V10']

- Bounds:   n/a
```

</details>


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Towards #20 
- Towards #11 
- Fixes #31
- Closes #4

## Checklist

- [ ] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
