### PR TITLE
Add additional MetPy and cf-units tests

### DIFF
--- a/ci/environment-upstream-dev.yml
+++ b/ci/environment-upstream-dev.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - cf-units
   - donfig
   - metpy
   - netcdf4

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -3,6 +3,7 @@ channels:
   - conda-forge
   - nodefaults
 dependencies:
+  - cf-units
   - cf_xarray
   - donfig
   - metpy

--- a/tests/test_metpy.py
+++ b/tests/test_metpy.py
@@ -1,5 +1,6 @@
 import metpy
 import pytest
+import xarray as xr
 
 import xwrf
 
@@ -21,3 +22,33 @@ def test_metpy_parse_cf(sample_dataset):
     ds = sample_dataset.xwrf.postprocess().metpy.parse_cf()
     assert 'metpy_crs' in ds.coords
     assert isinstance(ds.metpy_crs.data.item(), metpy.plots.mapping.CFProjection)
+    assert ds['wrf_projection'].item() == ds['metpy_crs'].metpy.pyproj_crs
+
+
+@pytest.mark.parametrize('sample_dataset', ['lambert_conformal', 'mercator'], indirect=True)
+def test_metpy_coordinate_identification(sample_dataset):
+    ds = sample_dataset.xwrf.postprocess()
+    # U staggered
+    xr.testing.assert_identical(ds['U'].metpy.x, ds['x_stag'])
+    xr.testing.assert_identical(ds['U'].metpy.y, ds['y'])
+    xr.testing.assert_identical(ds['U'].metpy.time, ds['Time'])
+    xr.testing.assert_identical(ds['U'].metpy.longitude, ds['XLONG_U'])
+    xr.testing.assert_identical(ds['U'].metpy.latitude, ds['XLAT_U'])
+    # V staggered
+    xr.testing.assert_identical(ds['V'].metpy.x, ds['x'])
+    xr.testing.assert_identical(ds['V'].metpy.y, ds['y_stag'])
+    xr.testing.assert_identical(ds['V'].metpy.time, ds['Time'])
+    xr.testing.assert_identical(ds['V'].metpy.longitude, ds['XLONG_V'])
+    xr.testing.assert_identical(ds['V'].metpy.latitude, ds['XLAT_V'])
+
+
+@pytest.mark.parametrize(
+    'sample_dataset, axis_mapping, test_varname',
+    [('lambert_conformal', {'x': 3, 'y': 2, 'vertical': 1, 'time': 0}, 'QVAPOR')],
+    indirect=['sample_dataset'],
+)
+def test_metpy_axis_identification(sample_dataset, axis_mapping, test_varname):
+    da = sample_dataset.xwrf.postprocess()[test_varname]
+    for axis_type, axis_number in axis_mapping.items():
+        assert da.metpy.find_axis_number(axis_type) == axis_number
+        assert da.metpy.find_axis_name(axis_type) == da.dims[axis_number]

--- a/tests/test_udunits.py
+++ b/tests/test_udunits.py
@@ -1,0 +1,51 @@
+import pytest
+
+import xwrf
+
+from . import importorskip
+
+
+@pytest.fixture(scope='session')
+def sample_dataset(request):
+    return xwrf.tutorial.open_dataset(request.param)
+
+
+@importorskip('cf_units')
+@pytest.mark.parametrize('sample_dataset', ['lambert_conformal'], indirect=True)
+@pytest.mark.parametrize(
+    'variable,cf_definition_string',
+    (
+        ('QNRAIN', 'kg-1'),
+        ('NOAHRES', 'kg.s-3'),
+        ('THIS_IS_AN_IDEAL_RUN', '?'),
+        ('SAVE_TOPO_FROM_REAL', '?'),
+        ('OL4', '?'),
+        ('VAR_SSO', 'm2'),
+        ('SEAICE', '?'),
+    ),
+)
+def test_problematic_units_against_udunits_wrfout(sample_dataset, variable, cf_definition_string):
+    from cf_units import Unit
+
+    ds = sample_dataset.xwrf.postprocess()
+    assert Unit(ds[variable].attrs.get('units', '')).definition == cf_definition_string
+
+
+@importorskip('cf_units')
+@pytest.mark.parametrize('sample_dataset', ['met_em_sample'], indirect=True)
+@pytest.mark.parametrize(
+    'variable,cf_definition_string',
+    (
+        ('OL4', '1'),
+        ('GREENFRAC', '1'),
+        ('PRES', 'm-1.kg.s-2'),
+        ('ST', 'K'),
+        ('SOILTEMP', 'K'),
+        ('RH', '0.01 1'),
+    ),
+)
+def test_problematic_units_against_udunits_met_em(sample_dataset, variable, cf_definition_string):
+    from cf_units import Unit
+
+    ds = sample_dataset.xwrf.postprocess()
+    assert Unit(ds[variable].attrs.get('units', '')).definition == cf_definition_string


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

This includes the changes I mentioned in https://github.com/ncar-xdev/xwrf/pull/50#issuecomment-1051308823, namely adding MetPy coordinate ID tests as well as changing the "bracket cleaning" to meet CF behavior, rather than MetPy's existing parsing ([which is faulty on regular parentheses](https://github.com/Unidata/MetPy/issues/1362#issuecomment-1051310199)).

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

## Checklist

- [x] Unit tests for the changes exist
- [ ] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
