### PR TITLE
Add `xwrf.show_versions()` function

### DIFF
--- a/.github/ISSUE_TEMPLATE/bugreport.yml
+++ b/.github/ISSUE_TEMPLATE/bugreport.yml
@@ -33,25 +33,15 @@ body:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for markdown backticks.
       render: python
-  - type: dropdown
-    id: version
+  - type: textarea
+    id: show-versions
     attributes:
-      label: Version
-      description: What version of xwrf are you running?
-      options:
-        - main
+      label: Environment
+      description: |
+        Paste the output of `xwrf.show_versions()` here
+      render: python
     validations:
       required: true
-  - type: dropdown
-    id: python-version
-    attributes:
-      label: Which Python version are you using?
-      multiple: true
-      options:
-        - '3.7'
-        - '3.8'
-        - '3.9'
-        - '3.10'
 
   - type: textarea
     id: extra

--- a/tests/test_version_report.py
+++ b/tests/test_version_report.py
@@ -1,0 +1,7 @@
+import xwrf
+
+
+def test_xwrf_version_report():
+    info = xwrf.show_versions(as_dict=True)
+    assert set(info.keys()) == {'sys_info', 'packages_info'}
+    assert info['packages_info']['xwrf'] == xwrf.__version__

--- a/xwrf/__init__.py
+++ b/xwrf/__init__.py
@@ -7,6 +7,7 @@ from pkg_resources import DistributionNotFound, get_distribution
 from . import postprocess, tutorial
 from .accessors import WRFDataArrayAccessor, WRFDatasetAccessor
 from .config import config
+from .version_report import show_versions
 
 try:
     __version__ = get_distribution(__name__).version

--- a/xwrf/version_report.py
+++ b/xwrf/version_report.py
@@ -99,7 +99,7 @@ def show_versions(as_dict: bool = False) -> None | dict[str, str]:
     print('\n'.join(f'{key:<12}: {value}' for (key, value) in sys_info))
     print('\nInstalled Python Packages')
     print('-------------------------')
-    print('\n'.join(f'{modname:<11}: {version}' for (modname, version) in packages_info))
+    print('\n'.join(f'{modname:<12}: {version}' for (modname, version) in packages_info))
 
     if as_dict:
         return {'sys_info': sys_info, 'packages_info': packages_blob}

--- a/xwrf/version_report.py
+++ b/xwrf/version_report.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib
+import locale
+import os
+import pathlib
+import platform
+import struct
+import subprocess
+import sys
+
+
+def get_sys_info() -> dict[str, str]:
+    """Returns system information as a dict"""
+
+    # get full commit hash
+    commit = None
+    if pathlib.Path('.git').is_dir() and pathlib.Path('xwrf').is_dir():
+        try:
+            pipe = subprocess.Popen(
+                'git log --format="%H" -n 1'.split(' '),
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+            so, _ = pipe.communicate()
+        except Exception:
+            pass
+        else:
+            if pipe.returncode == 0:
+                commit = so
+                try:
+                    commit = so.decode('utf-8')
+                except ValueError:
+                    pass
+                commit = commit.strip().strip('"')
+
+    blob = [('xWRF commit', commit)]
+    try:
+        (sysname, _nodename, release, _version, machine, processor) = platform.uname()
+        blob.extend(
+            [
+                ('python', sys.version),
+                ('python-bits', struct.calcsize('P') * 8),
+                ('OS', f'{sysname}'),
+                ('OS-release', f'{release}'),
+                ('machine', f'{machine}'),
+                ('processor', f'{processor}'),
+                ('byteorder', f'{sys.byteorder}'),
+                ('LC_ALL', f'{os.environ.get("LC_ALL", "None")}'),
+                ('LANG', f'{os.environ.get("LANG", "None")}'),
+                ('LOCALE', f'{locale.getlocale()}'),
+            ]
+        )
+    except Exception:
+        pass
+
+    return blob
+
+
+def show_versions(as_dict: bool = False) -> None | dict[str, str]:
+    """Print out versions of xwrf and its dependencies"""
+    packages = [
+        ('xwrf', lambda mod: mod.__version__),
+        ('xarray', lambda mod: mod.__version__),
+        ('numpy', lambda mod: mod.__version__),
+        ('pandas', lambda mod: mod.__version__),
+        ('matplotlib', lambda mod: mod.__version__),
+        ('dask', lambda mod: mod.__version__),
+        ('netCFD4', lambda mod: mod.__version__),
+        ('donfig', lambda mod: mod.__version__),
+        ('xgcm', lambda mod: mod.__version__),
+        ('pyproj', lambda mod: mod.__version__),
+        ('metpy', lambda mod: mod.__version__),
+        ('cf_xarray', lambda mod: mod.__version__),
+        ('pint', lambda mod: mod.__version__),
+        ('pooch', lambda mod: mod.__version__),
+    ]
+
+    packages_blob = {}
+    for (modname, version_func) in packages:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+        except Exception:
+            packages_blob[modname] = None
+
+        else:
+            try:
+                version = version_func(mod)
+                packages_blob[modname] = version
+            except Exception:
+                packages_blob[modname] = 'installed'
+    sys_info = get_sys_info()
+    packages_info = sorted(packages_blob.items())
+    print('\nSystem Information')
+    print('------------------')
+    print('\n'.join(f'{key:<12}: {value}' for (key, value) in sys_info))
+    print('\nInstalled Python Packages')
+    print('-------------------------')
+    print('\n'.join(f'{modname:<11}: {version}' for (modname, version) in packages_info))
+
+    if as_dict:
+        return {'sys_info': sys_info, 'packages_info': packages_blob}

--- a/xwrf/version_report.py
+++ b/xwrf/version_report.py
@@ -66,7 +66,7 @@ def show_versions(as_dict: bool = False) -> None | dict[str, str]:
         ('pandas', lambda mod: mod.__version__),
         ('matplotlib', lambda mod: mod.__version__),
         ('dask', lambda mod: mod.__version__),
-        ('netCFD4', lambda mod: mod.__version__),
+        ('netCDF4', lambda mod: mod.__version__),
         ('donfig', lambda mod: mod.__version__),
         ('xgcm', lambda mod: mod.__version__),
         ('pyproj', lambda mod: mod.__version__),


### PR DESCRIPTION
<!-- Thanks for submitting a PR, your contribution is really appreciated! -->
<!-- Unless your change is trivial, please create an issue to discuss the change before creating a PR -->
<!-- Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

## Change Summary

<!-- Please give a short summary of the changes. -->

```python
In [3]: xwrf.show_versions()

System Information
------------------
xWRF commit : ea3ebd8e0bf2d64d1d76ab89dcae302d5ac04db6
python      : 3.10.2 | packaged by conda-forge | (main, Feb  1 2022, 19:28:35) [GCC 9.4.0]
python-bits : 64
OS          : Linux
OS-release  : 5.13.0-30-generic
machine     : x86_64
processor   : x86_64
byteorder   : little
LC_ALL      : None
LANG        : en_US.UTF-8
LOCALE      : ('en_US', 'UTF-8')

Installed Python Packages
-------------------------
cf_xarray  : None
dask       : 2022.02.1
donfig     : 0.7.0
matplotlib : 3.5.1
metpy      : 1.2.0
netCDF4    : 1.5.8
numpy      : 1.22.3
pandas     : 1.4.1
pint       : 0.18
pooch      : v1.6.0
pyproj     : 3.3.0
xarray     : 2022.3.0
xgcm       : 0.6.1
xwrf       : 0.0.post53+dirty
```

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

- Closes #54 

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
- [ ] Documentation reflects the changes where applicable

<!--
Please add any other relevant info below:
-->
