### PR TITLE
Converted XTIME from datetime64 to timedelta, in line with its description

### DIFF
--- a/tests/test_postprocess.py
+++ b/tests/test_postprocess.py
@@ -92,7 +92,7 @@ def test_rename_dims(sample_dataset):
 def test_decode_times(times):
     ds = xr.Dataset({'Times': times})
     dsa = xwrf.postprocess._decode_times(ds)
-    assert dsa['Time'].dtype == 'datetime64[ns]'
+    assert np.issubdtype(dsa['Time'].dtype, np.datetime64)
     assert dsa['Time'].attrs['long_name'] == 'Time'
     assert dsa['Time'].attrs['standard_name'] == 'time'
 
@@ -100,14 +100,14 @@ def test_decode_times(times):
 @pytest.mark.parametrize(
     'sample_dataset_with_kwargs,xtime_dtype',
     [
-        (('mercator', {'decode_times': True}), 'timedelta64[ns]'),
-        (('mercator', {'decode_times': False}), 'float32'),
+        (('mercator', {'decode_times': True}), np.timedelta64),
+        (('mercator', {'decode_times': False}), np.float32),
     ],
     indirect=['sample_dataset_with_kwargs'],
 )
 def test_xtime_handling(sample_dataset_with_kwargs, xtime_dtype):
     dataset = xwrf.postprocess._decode_times(sample_dataset_with_kwargs)
-    assert dataset.XTIME.dtype == xtime_dtype
+    assert np.issubdtype(dataset.XTIME.dtype, xtime_dtype)
 
 
 @pytest.mark.parametrize('sample_dataset', ['lambert_conformal'], indirect=True)

--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -25,7 +25,7 @@ def _decode_times(ds: xr.Dataset) -> xr.Dataset:
     ds = ds.assign_coords({'Time': _time})
     ds.Time.attrs = {'long_name': 'Time', 'standard_name': 'time'}
     # make XTIME be consistent with its description
-    if 'XTIME' in ds.variables and ds.XTIME.dtype == 'datetime64[ns]':
+    if 'XTIME' in ds.variables and np.issubdtype(ds.XTIME.dtype, np.datetime64):
         ds['XTIME'].data = (
             ds.XTIME.data
             - pd.to_datetime(

--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -24,6 +24,14 @@ def _decode_times(ds: xr.Dataset) -> xr.Dataset:
         )
     ds = ds.assign_coords({'Time': _time})
     ds.Time.attrs = {'long_name': 'Time', 'standard_name': 'time'}
+    # make XTIME be consistent with its description
+    if 'XTIME' in ds.variables and ds.XTIME.dtype == 'datetime64[ns]':
+        ds['XTIME'].data = (
+            ds.XTIME.data
+            - pd.to_datetime(
+                ds['XTIME'].description, format='minutes since %Y-%m-%d %H:%M:%S'
+            ).to_datetime64()
+        )
     return ds
 
 

--- a/xwrf/postprocess.py
+++ b/xwrf/postprocess.py
@@ -3,6 +3,7 @@ from __future__ import annotations  # noqa: F401
 import re
 import warnings
 
+import numpy as np
 import pandas as pd
 import xarray as xr
 


### PR DESCRIPTION
## Change Summary

Now casting `XTIME` to timedelta64 from simulation start like the description states. Unfortunately, `xarray` can't handle `timedelta64[m]` datetypes, this would have been ideal.

I'll look into adding some tests

## Checklist

- [x] Unit tests for the changes exist
- [x] Tests pass on CI
